### PR TITLE
Add positionName to resultMetadata

### DIFF
--- a/Schema/sql/ResultsTables.sql
+++ b/Schema/sql/ResultsTables.sql
@@ -69,11 +69,13 @@ ALTER TABLE RDO.Result ADD CONSTRAINT PK_Result PRIMARY KEY(id);
 CREATE TABLE RDO.ResultMetadata (
   id BIGINT NOT NULL,
   structureId BIGINT NOT NULL,
-  positionId BIGINT NOT NULL,
+  positionId BIGINT,
+  positionName VARCHAR(512) NOT NULL,
   settingsId BIGINT NOT NULL,
   resultTypeCode VARCHAR(32),
   granularityCode VARCHAR(80));
 ALTER TABLE RDO.ResultMetadata ADD CONSTRAINT PK_ResultMetadata PRIMARY KEY(id);
+
 
 CREATE TABLE RDO.Result_ELT (
   resultId BIGINT NOT NULL,


### PR DESCRIPTION
## TICKET

## Change Description
* Making positionId optional - portfolio positions don't have positionIds if they don't appear in SDL structures.  E.g. the gross position of portfolio ABC.

## Notes
*

### Root Cause (_if_bug)
It was not possible to specifically address results to portfolio positions, as they do not have Ids.  They only have names.

## Checklist

- [ ] added unit tests

## Notify


